### PR TITLE
docs: clarify FeeCollector redemption behaviour

### DIFF
--- a/technical/cove/rfc.mdx
+++ b/technical/cove/rfc.mdx
@@ -668,6 +668,10 @@ Where:
 
 The calculated fee is minted as new shares to the fee collector contract. The `FeeCollector` contract then divides the fee between the protocol treasury and the strategy sponsor according to the configured split percentage for each basket.
 
+<Accordion title="Details (Click to expand)">
+The `FeeCollector` contract will only use the `proRataRedeem` function for synchronous claiming of fees. This ensures that any tokens sent to the `FeeCollector` by other users will be ignored in the fee calculation, as the `proRataRedeem` function burns the shares immediately and transfers the underlying assets to the fee recipients. The `FeeCollector` will not use the asynchronous redemption process, which could potentially lead to claimable fallback shares being included in the total supply used for fee calculation.
+</Accordion>
+
 ### Swap Fee
 
 The swap fee is a global fee applied to all internal token swaps during rebalancing. It is charged on both the buy and sell tokens of each trade. The fee is calculated as follows:


### PR DESCRIPTION
Adds this section:

<img width="765" alt="Screenshot 2025-01-24 at 5 15 02 PM" src="https://github.com/user-attachments/assets/c644f795-6475-4429-88fe-60ccfd54d711" />