### PR TITLE
docs: reallocate prisma rewards to the rest of the vaults

### DIFF
--- a/ecosystem/token/liquidity-mining.mdx
+++ b/ecosystem/token/liquidity-mining.mdx
@@ -194,7 +194,7 @@ bootstrapping the new USDS vault.  Epoch 8 will begin around Thursday April
 | WETH-2               | 35,000 $COVE        |
 | USDS                 | 50,000 $COVE        |
 
-Effective April 21st, 2024, the emissions previously allocated to LP Yearn PRISMA (v2) vault will be proportionally redistributed across all remaining active vaults. For additional information regarding this reallocation, please refer to the official announcement [here](https://x.com/ResupplyFi/status/1902699967090766045).
+Effective April 15th, 2024, the emissions previously allocated to LP Yearn PRISMA (v2) vault will be proportionally redistributed across all remaining active vaults. For additional information regarding this reallocation, please refer to the official announcement [here](https://x.com/ResupplyFi/status/1902699967090766045).
 
 The revised emission schedule for participating vaults is detailed below:
 


### PR DESCRIPTION
This pull request includes updates to the emission schedule for various vaults in the `ecosystem/token/liquidity-mining.mdx` file. The changes include the redistribution of emissions and the addition of a new emission schedule.

Key changes:

* Added a note about the redistribution of emissions previously allocated to the LP Yearn PRISMA (v2) vault, effective April 15th, 2024.
* Detailed the revised emission schedule for participating vaults, listing the new emissions for each target.