### PR TITLE
chore: update to curve.finance domain

### DIFF
--- a/ecosystem/boosties/coveyfi.mdx
+++ b/ecosystem/boosties/coveyfi.mdx
@@ -44,6 +44,6 @@ This mechanism ensures that while the governance tokens are locked and contribut
 ### coveYFI/YFI Curve Pool
 
 A coveYFI/YFI Curve pool has been created
-[here](https://curve.fi/#/ethereum/pools/factory-stable-ng-152).
+[here](https://www.curve.finance/dex/ethereum/pools/factory-stable-ng-152/deposit/).
 
 Liquidity will be incentivized in future epochs.

--- a/ecosystem/token/launchpad.mdx
+++ b/ecosystem/token/launchpad.mdx
@@ -30,7 +30,7 @@ ensures fairness for all users, though the exact proportion is uncertain
 beforehand.
 
 Funds were used to purchase YFI and seed the [coveYFI/YFI Curve
-pool](https://curve.fi/#/ethereum/pools/factory-stable-ng-152) as protocol
+pool](https://www.curve.finance/dex/ethereum/pools/factory-stable-ng-152/deposit/) as protocol
 owned liquidity (PoL). The purchase was facilitated by the [community
 multisig](/ecosystem/token/governance#community-multisig).
 

--- a/resources/coveyfi-curve-pool.mdx
+++ b/resources/coveyfi-curve-pool.mdx
@@ -1,4 +1,4 @@
 ---
 title: "coveYFI/YFI Curve Pool"
-url: "https://curve.fi/#/ethereum/pools/factory-stable-ng-152"
+url: "https://www.curve.finance/dex/ethereum/pools/factory-stable-ng-152/deposit/"
 ---


### PR DESCRIPTION
Replace curve domains with the new urls

https://news.curve.finance/curve-domain-incident/