### PR TITLE
chore: add Base mainnet contract addresses

### DIFF
--- a/security/contract-addresses.mdx
+++ b/security/contract-addresses.mdx
@@ -154,3 +154,17 @@ mode: "wide"
 | PythOracle_USDS-USD                                          | [0x06fAa7646AE8001097EdFfd2217c341A54B472Dc](https://etherscan.io/address/0x06fAa7646AE8001097EdFfd2217c341A54B472Dc#code) |
 | StrategyRegistry                                             | [0x5877f26793c44358B0757617f4e3380C344fF523](https://etherscan.io/address/0x5877f26793c44358B0757617f4e3380C344fF523#code) |
 | TimelockController                                           | [0xF395339b12642aC27e08E72fE8aBEA0dc3a956A8](https://etherscan.io/address/0xF395339b12642aC27e08E72fE8aBEA0dc3a956A8#code) |
+
+# Base
+
+## Cove
+
+| Contract       | Address                                                                                                                   |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| MasterRegistry | [0x2f507F98a22b5f5c17423Aa8365eAef5bc6Efe0f](https://basescan.org/address/0x2f507F98a22b5f5c17423Aa8365eAef5bc6Efe0f#code) |
+
+## Cove Staging
+
+| Contract               | Address                                                                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| MasterRegistry | [0x44bB20e5A3CC2cBdfB7520Aa76281019723382Cb](https://basescan.org/address/0x44bB20e5A3CC2cBdfB7520Aa76281019723382Cb#code) |


### PR DESCRIPTION
## Summary
- Added Base mainnet contract addresses to the documentation
- Added MasterRegistry (production) at `0x2f507F98a22b5f5c17423Aa8365eAef5bc6Efe0f`
- Added Staging_MasterRegistry at `0x44bB20e5A3CC2cBdfB7520Aa76281019723382Cb`

## Test plan
- [ ] Verify contract addresses match deployments from https://github.com/Storm-Labs-Inc/cove-contracts-boosties/pull/353
- [ ] Verify Basescan links are working correctly
- [ ] Review documentation structure matches Ethereum sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)